### PR TITLE
Proper logs if the STH port is already occupied

### DIFF
--- a/src/sth_app.js
+++ b/src/sth_app.js
@@ -37,7 +37,11 @@
     }
 
     if (err) {
-      sthLogger.fatal(err.toString(), {
+      var message = err.toString();
+      if (message.indexOf('listen EADDRINUSE') !== -1) {
+        message += ' (another STH instance maybe already listening on the same port)';
+      }
+      sthLogger.fatal(message, {
         operationType: sthConfig.OPERATION_TYPE.SHUTDOWN
       });
     }

--- a/src/sth_server.js
+++ b/src/sth_server.js
@@ -402,8 +402,8 @@
     ]);
 
     // Start the server
-    server.start(function () {
-      return callback(null, server);
+    server.start(function (err) {
+      return callback(err, server);
     });
   }
 
@@ -416,13 +416,13 @@
     sthLogger.info('Stopping the STH server...', {
       operationType: sthConfig.OPERATION_TYPE.SERVER_STOP
     });
-    if (server) {
-      server.stop(function () {
+    if (server && server.info.started && server.info.listener) {
+      server.stop(function (err) {
         // Server successfully stopped
         sthLogger.info('hapi server successfully stopped', {
           operationType: sthConfig.OPERATION_TYPE.SERVER_STOP
         });
-        return callback();
+        return callback(err);
       });
     } else {
       sthLogger.info('No hapi server running', {

--- a/test/node/sth_app_test.js
+++ b/test/node/sth_app_test.js
@@ -62,7 +62,7 @@
         sthConfig.PORT,
         sthApp.sthDatabase,
         function(err, server) {
-          expect(err).to.equal(null);
+          expect(err).to.equal(undefined);
           expect(server).to.be.a(hapi.Server);
           done();
         });


### PR DESCRIPTION
- Implements https://github.com/telefonicaid/IoT-STH/issues/25
- 100% tests passed.
- Assigned to @frbattid 
- Comments from @iariasleon are more than welcome ;)

Currently, when there is already another instance of the STH component listening on the same port, the following logs are generated:
```
➜  IoT-STH git:(feature/multi-instances) ✗ npm start

> fiware-sth-rest-api@0.1.0 start /Users/gtv/Documents/git/telefonicaid/IoT-STH
> node ./src/sth_app

time=2015-04-22T11:39:55.663Z | lvl=INFO | corr=NA | trans=NA | op=OPER_STH_DB_CONN_OPEN | msg=Connection to MongoDB mongodb://@localhost:27017/orion successfully established
time=2015-04-22T11:39:55.707Z | lvl=FATAL | corr=NA | trans=NA | op=OPER_STH_SHUTDOWN | msg=Error: listen EADDRINUSE (another STH instance maybe already listening on the same port), alarm_status=ALARM
time=2015-04-22T11:39:55.709Z | lvl=INFO | corr=NA | trans=NA | op=OPER_STH_SERVER_STOP | msg=Stopping the STH server...
time=2015-04-22T11:39:55.709Z | lvl=INFO | corr=NA | trans=NA | op=OPER_STH_SERVER_STOP | msg=No hapi server running
time=2015-04-22T11:39:55.710Z | lvl=INFO | corr=NA | trans=NA | op=OPER_STH_DB_CONN_CLOSE | msg=Closing the connection to the database...
time=2015-04-22T11:39:55.715Z | lvl=INFO | corr=NA | trans=NA | op=OPER_STH_DB_CONN_CLOSE | msg=Connection to MongoDb succesfully closed

npm ERR! Darwin 14.3.0
npm ERR! argv "/Users/gtv/.nvm/v0.12.0/bin/node" "/Users/gtv/.nvm/v0.12.0/bin/npm" "start"
npm ERR! node v0.12.0
npm ERR! npm  v2.5.1
npm ERR! code ELIFECYCLE
npm ERR! fiware-sth-rest-api@0.1.0 start: `node ./src/sth_app`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the fiware-sth-rest-api@0.1.0 start script 'node ./src/sth_app'.
npm ERR! This is most likely a problem with the fiware-sth-rest-api package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     node ./src/sth_app
npm ERR! You can get their info via:
npm ERR!     npm owner ls fiware-sth-rest-api
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/gtv/Documents/git/telefonicaid/IoT-STH/npm-debug.log
```