### PR TITLE
Showing the selected data model via logs

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "fiware-sth-rest-api",
+  "name": "fiware-comet",
   "description": "Node.js app exposing the Short Time Historic (STH) FIWARE component REST API for reading",
   "version": "0.1.0",
   "devDependencies": {

--- a/src/sth_app.js
+++ b/src/sth_app.js
@@ -62,6 +62,14 @@
       return process.nextTick(callback);
     }
 
+    sthLogger.info(
+      'Data model set to %s',
+      sthConfig.DATA_MODEL,
+      {
+        operationType: sthConfig.OPERATION_TYPE.SERVER_START
+      }
+    );
+
     // Connect to the MongoDB database
     sthDatabase.connect(sthConfig.DB_AUTHENTICATION, sthConfig.DB_URI, sthConfig.REPLICA_SET,
       sthConfig.SERVICE, sthConfig.POOL_SIZE,


### PR DESCRIPTION
- 100% tests passed
- Assigned to @frbattid 

Thanks to this PR, now the starting logs of the STH components are as follows:
```
➜  IoT-STH git:(task/showing-data-model-in-logs) STH_HOST=0.0.0.0 STH_PORT=8667 DATA_MODEL=collection-per-entity npm start                

> fiware-comet@0.1.0 start /Users/gtv/Documents/git/telefonicaid/IoT-STH
> node ./src/sth_app

time=2015-04-23T13:24:35.861Z | lvl=INFO | corr=NA | trans=NA | op=OPER_STH_SERVER_START | msg=Data model set to collection-per-entity
time=2015-04-23T13:24:36.018Z | lvl=INFO | corr=NA | trans=NA | op=OPER_STH_DB_CONN_OPEN | msg=Connection to MongoDB mongodb://@localhost:27017/orion successfully established
time=2015-04-23T13:24:36.080Z | lvl=INFO | corr=NA | trans=NA | op=OPER_STH_SERVER_START | msg=Server started at http://0.0.0.0:8667
```
