### PR TITLE
Rotating log file based on size in bytes

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,8 @@ The script accepts the following parameters as environment variables:
 - LOG_LEVEL: The logging level of the messages. Messages with a level equal or superior to this will be logged. Optional. Default value: "info".
 - LOG_TO_CONSOLE: A flag indicating if the logs should be sent to the console. Optional. Default value: true.
 - LOG_TO_FILE: A flag indicating if the logs should be sent to a file. Optional. Default value: true.
+- LOG_FILE_MAX_SIZE_IN_BYTES: Maximum size in bytes of the log files. If the maximum size is reached, a new log file is created incrementing
+a counter used as the suffix for the log file name. Optional. Default value: undefined.
 - LOG_DIR: The path to a directory where the log file will be searched for or created if it does not exist. Optional. Default value: "./log".
 - LOG_FILE_NAME: The name of the file where the logs will be stored. Optional. Default value: "sth_app.log".
 - DB_PREFIX: The prefix to be added to the service for the creation of the databases. More information below. Optional. Default value: "sth".

--- a/src/sth_configuration.js
+++ b/src/sth_configuration.js
@@ -63,6 +63,7 @@
   module.exports.LOG_LEVEL = ENV.LOG_LEVEL || 'info';
   module.exports.LOG_TO_CONSOLE = ENV.LOG_TO_CONSOLE !== 'false';
   module.exports.LOG_TO_FILE = ENV.LOG_TO_FILE !== 'false';
+  module.exports.LOG_FILE_MAX_SIZE_IN_BYTES = ENV.LOG_FILE_MAX_SIZE_IN_BYTES;
   module.exports.LOG_DIR = ENV.LOG_DIR || '.' + path.sep + 'log';
   module.exports.LOG_FILE_NAME = ENV.LOG_FILE_NAME || 'sth_app.log';
   module.exports.SERVICE = ENV.SERVICE || 'orion';

--- a/src/sth_logger.js
+++ b/src/sth_logger.js
@@ -101,6 +101,7 @@
       transports.push(new winston.transports.File({
         level: sthConfig.LOG_LEVEL,
         filename: sthConfig.LOG_DIR + path.sep + sthConfig.LOG_FILE_NAME,
+        maxsize: sthConfig.LOG_FILE_MAX_SIZE_IN_BYTES,
         json: false,
         formatter: formatter
       }));


### PR DESCRIPTION
- Implements https://github.com/telefonicaid/IoT-STH/issues/17
- 100% tests passed
- Assigned to @frbattid 

New environment variable LOG_FILE_MAX_SIZE_IN_BYTES sets the maximum size of the log files created. If the size is reached, a new file is created incrementing a counter in its name.