### PR TITLE
Removing the option to select the data model to use when storing the event and the aggregated data

### DIFF
--- a/README.md
+++ b/README.md
@@ -347,7 +347,7 @@ be more than 120 bytes using UTF-8 or MongoDB will complain and will not create 
 would be stored by the STH. The hash function used is SHA-512. A warning message is logged in case this happens.
 
 In case of using hashes as part of the collection names and to let the user or developer easily recover this information,
-a collection named ```DB_COLLECTION_PREFIX + _collection_name``` is created and fed with information regarding the mapping
+a collection named ```DB_COLLECTION_PREFIX + _collection_names``` is created and fed with information regarding the mapping
 of the collection names and the combination of concrete services, service paths, entities and attributes.
 
 [Top](#section0)

--- a/config.js
+++ b/config.js
@@ -50,13 +50,7 @@ config.database = {
   //  (currently limited to 120 bytes). In case of hashing, information about the final collection name
   //  and its correspondence to each concrete service path, entity and (if applicable) attribute
   //  is stored in a collection named `COLLECTION_PREFIX + "collection_names"`. Default value: "false".
-  shouldHash: 'false',
-  // The data model to use. Currently 3 possible values are supported: collection-per-service-path
-  //  (which creates a MongoDB collection per service patch to store the data), collection-per-entity
-  //  (which creates a MongoDB collection per service path and entity to store the data) and
-  //  collection-per-attribute (which creates a collection per service path, entity and attribute
-  //  to store the data). Default value: "collection-per-entity".
-  dataModel: 'collection-per-entity'
+  shouldHash: 'false'
 };
 
 // Logging configuration

--- a/src/sth_app.js
+++ b/src/sth_app.js
@@ -74,14 +74,6 @@
       }
     );
 
-    sthLogger.info(
-      'Data model set to %s',
-      sthConfig.DATA_MODEL,
-      {
-        operationType: sthConfig.OPERATION_TYPE.SERVER_START
-      }
-    );
-
     // Connect to the MongoDB database
     sthDatabase.connect(sthConfig.DB_AUTHENTICATION, sthConfig.DB_URI, sthConfig.REPLICA_SET,
       sthConfig.DEFAULT_SERVICE, sthConfig.POOL_SIZE,

--- a/src/sth_configuration.js
+++ b/src/sth_configuration.js
@@ -48,11 +48,6 @@
     },
     DB_PREFIX: ENV.DB_PREFIX || config.database.prefix || 'sth_',
     COLLECTION_PREFIX: ENV.COLLECTION_PREFIX || config.database.collectionPrefix || 'sth_',
-    DATA_MODELS: {
-      COLLECTIONS_PER_SERVICE_PATH: 'collection-per-service-path',
-      COLLECTIONS_PER_ENTITY: 'collection-per-entity',
-      COLLECTIONS_PER_ATTRIBUTE: 'collection-per-attribute'
-    },
     DATA_TO_STORE: {
       ONLY_RAW: 'only-raw',
       ONLY_AGGREGATED: 'only-aggregated',
@@ -125,21 +120,6 @@
     module.exports.SHOULD_STORE = config.database.shouldStore;
   } else {
     module.exports.SHOULD_STORE = 'both';
-  }
-  if ([
-      module.exports.DATA_MODELS.COLLECTIONS_PER_SERVICE_PATH,
-      module.exports.DATA_MODELS.COLLECTIONS_PER_ENTITY,
-      module.exports.DATA_MODELS.COLLECTIONS_PER_ATTRIBUTE
-    ].indexOf(ENV.DATA_MODEL) !== -1) {
-    module.exports.DATA_MODEL = ENV.DATA_MODEL;
-  } else if([
-      module.exports.DATA_MODELS.COLLECTIONS_PER_SERVICE_PATH,
-      module.exports.DATA_MODELS.COLLECTIONS_PER_ENTITY,
-      module.exports.DATA_MODELS.COLLECTIONS_PER_ATTRIBUTE
-    ].indexOf(config.database.dataModel) !== -1) {
-    module.exports.DATA_MODEL = config.database.dataModel;
-  } else {
-    module.exports.DATA_MODEL = 'collection-per-entity';
   }
   if (ENV.SHOULD_HASH) {
     module.exports.SHOULD_HASH = ENV.SHOULD_HASH !== 'false';

--- a/src/sth_database.js
+++ b/src/sth_database.js
@@ -13,12 +13,19 @@
   var MAX_NAMESPACE_SIZE_IN_BYTES = 120,
       MIN_HASH_SIZE_IN_BYTES = 20;
 
+  var DATA_MODELS = {
+    COLLECTIONS_PER_SERVICE_PATH: 'collection-per-service-path',
+    COLLECTIONS_PER_ENTITY: 'collection-per-entity',
+    COLLECTIONS_PER_ATTRIBUTE: 'collection-per-attribute'
+  };
+  var DATA_MODEL = DATA_MODELS.COLLECTIONS_PER_ENTITY;
+
   /**
    * Declares the Mongoose schemas.
    */
   function defineSchemas() {
-    switch (sthConfig.DATA_MODEL) {
-      case sthConfig.DATA_MODELS.COLLECTIONS_PER_SERVICE_PATH:
+    switch (DATA_MODEL) {
+      case DATA_MODELS.COLLECTIONS_PER_SERVICE_PATH:
         eventSchema = mongoose.Schema({
           recvTime: Date,
           entityId: String,
@@ -28,7 +35,7 @@
           attrValue: Number
         });
         break;
-      case sthConfig.DATA_MODELS.COLLECTIONS_PER_ENTITY:
+      case DATA_MODELS.COLLECTIONS_PER_ENTITY:
         eventSchema = mongoose.Schema({
           recvTime: Date,
           attrName: String,
@@ -36,7 +43,7 @@
           attrValue: Number
         });
         break;
-      case sthConfig.DATA_MODELS.COLLECTIONS_PER_ATTRIBUTE:
+      case DATA_MODELS.COLLECTIONS_PER_ATTRIBUTE:
         eventSchema = mongoose.Schema({
           recvTime: Date,
           attrType: String,
@@ -45,8 +52,8 @@
         break;
     }
 
-    switch (sthConfig.DATA_MODEL) {
-      case sthConfig.DATA_MODELS.COLLECTIONS_PER_SERVICE_PATH:
+    switch (DATA_MODEL) {
+      case DATA_MODELS.COLLECTIONS_PER_SERVICE_PATH:
         aggregatedSchema = mongoose.Schema({
           _id: {
             type: {
@@ -70,7 +77,7 @@
           }]
         });
         break;
-      case sthConfig.DATA_MODELS.COLLECTIONS_PER_ENTITY:
+      case DATA_MODELS.COLLECTIONS_PER_ENTITY:
         aggregatedSchema = mongoose.Schema({
           _id: {
             type: {
@@ -92,7 +99,7 @@
           }]
         });
         break;
-      case sthConfig.DATA_MODELS.COLLECTIONS_PER_ATTRIBUTE:
+      case DATA_MODELS.COLLECTIONS_PER_ATTRIBUTE:
         aggregatedSchema = mongoose.Schema({
           _id: {
             type: {
@@ -189,14 +196,14 @@
    */
   function getCollectionName4Events(databaseName, servicePath, entityId, entityType, attrName) {
     var collectionName4Events;
-    switch(sthConfig.DATA_MODEL) {
-      case sthConfig.DATA_MODELS.COLLECTIONS_PER_SERVICE_PATH:
+    switch(DATA_MODEL) {
+      case DATA_MODELS.COLLECTIONS_PER_SERVICE_PATH:
         collectionName4Events = servicePath;
         break;
-      case sthConfig.DATA_MODELS.COLLECTIONS_PER_ENTITY:
+      case DATA_MODELS.COLLECTIONS_PER_ENTITY:
         collectionName4Events =  servicePath + '_' + entityId + (entityType ? '_' + entityType : '');
         break;
-      case sthConfig.DATA_MODELS.COLLECTIONS_PER_ATTRIBUTE:
+      case DATA_MODELS.COLLECTIONS_PER_ATTRIBUTE:
         collectionName4Events =  servicePath + '_' + entityId + (entityType ? '_' + entityType : '') +
           '_' + attrName;
         break;
@@ -373,20 +380,20 @@
   function getRawData(collection, entityId, entityType, attrName, lastN, hLimit, hOffset,
                       from, to, callback) {
     var findCondition;
-    switch (sthConfig.DATA_MODEL) {
-      case sthConfig.DATA_MODELS.COLLECTIONS_PER_SERVICE_PATH:
+    switch (DATA_MODEL) {
+      case DATA_MODELS.COLLECTIONS_PER_SERVICE_PATH:
         findCondition = {
           'entityId': entityId,
           'entityType': entityType,
           'attrName': attrName
         };
         break;
-      case sthConfig.DATA_MODELS.COLLECTIONS_PER_ENTITY:
+      case DATA_MODELS.COLLECTIONS_PER_ENTITY:
         findCondition = {
           'attrName': attrName
         };
         break;
-      case sthConfig.DATA_MODELS.COLLECTIONS_PER_ATTRIBUTE:
+      case DATA_MODELS.COLLECTIONS_PER_ATTRIBUTE:
         findCondition = {};
         break;
     }
@@ -479,8 +486,8 @@
       pushAccumulator[aggregatedFunction] = '$points.' + aggregatedFunction;
 
       var matchCondition;
-      switch (sthConfig.DATA_MODEL) {
-        case sthConfig.DATA_MODELS.COLLECTIONS_PER_SERVICE_PATH:
+      switch (DATA_MODEL) {
+        case DATA_MODELS.COLLECTIONS_PER_SERVICE_PATH:
           matchCondition = {
             '_id.entityId': entityId,
             '_id.entityType': entityType,
@@ -489,14 +496,14 @@
             '_id.range': sthHelper.getRange(resolution)
           };
           break;
-        case sthConfig.DATA_MODELS.COLLECTIONS_PER_ENTITY:
+        case DATA_MODELS.COLLECTIONS_PER_ENTITY:
           matchCondition = {
             '_id.attrName': attrName,
             '_id.resolution': resolution,
             '_id.range': sthHelper.getRange(resolution)
           };
           break;
-        case sthConfig.DATA_MODELS.COLLECTIONS_PER_ATTRIBUTE:
+        case DATA_MODELS.COLLECTIONS_PER_ATTRIBUTE:
           matchCondition = {
             '_id.resolution': resolution,
             '_id.range': sthHelper.getRange(resolution)
@@ -508,8 +515,8 @@
       }
 
       var groupId;
-      switch (sthConfig.DATA_MODEL) {
-        case sthConfig.DATA_MODELS.COLLECTIONS_PER_SERVICE_PATH:
+      switch (DATA_MODEL) {
+        case DATA_MODELS.COLLECTIONS_PER_SERVICE_PATH:
           groupId = {
             entityId: '$_id.entityId',
             entityType: '$_id.entityType',
@@ -519,7 +526,7 @@
             resolution: '$_id.resolution'
           };
           break;
-        case sthConfig.DATA_MODELS.COLLECTIONS_PER_ENTITY:
+        case DATA_MODELS.COLLECTIONS_PER_ENTITY:
           groupId = {
             attrName: '$_id.attrName',
             origin: '$_id.origin',
@@ -527,7 +534,7 @@
             resolution: '$_id.resolution'
           };
           break;
-        case sthConfig.DATA_MODELS.COLLECTIONS_PER_ATTRIBUTE:
+        case DATA_MODELS.COLLECTIONS_PER_ATTRIBUTE:
           groupId = {
             origin: '$_id.origin',
             range: '$_id.range',
@@ -566,8 +573,8 @@
       // Get the aggregated data from the database
       // Return the data in ascending order based on the origin
       var findCondition;
-      switch (sthConfig.DATA_MODEL) {
-        case sthConfig.DATA_MODELS.COLLECTIONS_PER_SERVICE_PATH:
+      switch (DATA_MODEL) {
+        case DATA_MODELS.COLLECTIONS_PER_SERVICE_PATH:
           findCondition = {
             '_id.entityId': entityId,
             '_id.entityType': entityType,
@@ -576,14 +583,14 @@
             '_id.range': sthHelper.getRange(resolution)
           };
           break;
-        case sthConfig.DATA_MODELS.COLLECTIONS_PER_ENTITY:
+        case DATA_MODELS.COLLECTIONS_PER_ENTITY:
           findCondition = {
             '_id.attrName': attrName,
             '_id.resolution': resolution,
             '_id.range': sthHelper.getRange(resolution)
           };
           break;
-        case sthConfig.DATA_MODELS.COLLECTIONS_PER_ATTRIBUTE:
+        case DATA_MODELS.COLLECTIONS_PER_ATTRIBUTE:
           findCondition = {
             '_id.resolution': resolution,
             '_id.range': sthHelper.getRange(resolution)
@@ -632,8 +639,8 @@
     }
 
     var aggregateUpdateCondition;
-    switch (sthConfig.DATA_MODEL) {
-      case sthConfig.DATA_MODELS.COLLECTIONS_PER_SERVICE_PATH:
+    switch (DATA_MODEL) {
+      case DATA_MODELS.COLLECTIONS_PER_SERVICE_PATH:
         aggregateUpdateCondition = {
           '_id.entityId': entityId,
           '_id.entityType': entityType,
@@ -644,7 +651,7 @@
           'points.offset': offset
         };
         break;
-      case sthConfig.DATA_MODELS.COLLECTIONS_PER_ENTITY:
+      case DATA_MODELS.COLLECTIONS_PER_ENTITY:
         aggregateUpdateCondition = {
           '_id.attrName': attrName,
           '_id.origin': sthHelper.getOrigin(recvTime, resolution),
@@ -653,7 +660,7 @@
           'points.offset': offset
         };
         break;
-      case sthConfig.DATA_MODELS.COLLECTIONS_PER_ATTRIBUTE:
+      case DATA_MODELS.COLLECTIONS_PER_ATTRIBUTE:
         aggregateUpdateCondition = {
           '_id.origin': sthHelper.getOrigin(recvTime, resolution),
           '_id.resolution': resolution,
@@ -879,8 +886,8 @@
     collection, recvTime, servicePath, entityId, entityType, attrName,
     attrType, attrValue, callback) {
     var theEvent;
-    switch (sthConfig.DATA_MODEL) {
-      case sthConfig.DATA_MODELS.COLLECTIONS_PER_SERVICE_PATH:
+    switch (DATA_MODEL) {
+      case DATA_MODELS.COLLECTIONS_PER_SERVICE_PATH:
         theEvent = {
           recvTime: recvTime,
           entityId: entityId,
@@ -890,7 +897,7 @@
           attrValue: attrValue
         };
         break;
-      case sthConfig.DATA_MODELS.COLLECTIONS_PER_ENTITY:
+      case DATA_MODELS.COLLECTIONS_PER_ENTITY:
         theEvent = {
           recvTime: recvTime,
           attrName: attrName,
@@ -898,7 +905,7 @@
           attrValue: attrValue
         };
         break;
-      case sthConfig.DATA_MODELS.COLLECTIONS_PER_ATTRIBUTE:
+      case DATA_MODELS.COLLECTIONS_PER_ATTRIBUTE:
         theEvent = {
           recvTime: recvTime,
           attrType: attrType,
@@ -1014,6 +1021,8 @@
       get connection() {
         return mongoose.connection;
       },
+      DATA_MODELS: DATA_MODELS,
+      DATA_MODEL: DATA_MODEL,
       connect: connect,
       closeConnection: closeConnection,
       getDatabase: getDatabase,

--- a/test/node/sth_app_test_helper.js
+++ b/test/node/sth_app_test_helper.js
@@ -33,8 +33,8 @@
     var attrValue = (Math.random() *
       (parseFloat(sthTestConfig.MAX_VALUE) - parseFloat(sthTestConfig.MIN_VALUE)) -
         Math.abs(parseFloat(sthTestConfig.MIN_VALUE))).toFixed(2);
-    switch (sthConfig.DATA_MODEL) {
-      case sthConfig.DATA_MODELS.COLLECTIONS_PER_SERVICE_PATH:
+    switch (sthDatabase.DATA_MODEL) {
+      case sthDatabase.DATA_MODELS.COLLECTIONS_PER_SERVICE_PATH:
         theEvent = {
           recvTime: recvTime,
           entityId: sthTestConfig.ENTITY_ID,
@@ -44,7 +44,7 @@
           attrValue: attrValue
         };
         break;
-      case sthConfig.DATA_MODELS.COLLECTIONS_PER_ENTITY:
+      case sthDatabase.DATA_MODELS.COLLECTIONS_PER_ENTITY:
         theEvent = {
           recvTime: recvTime,
           attrName: sthTestConfig.ATTRIBUTE_NAME,
@@ -52,7 +52,7 @@
           attrValue: attrValue
         };
         break;
-      case sthConfig.DATA_MODELS.COLLECTIONS_PER_ATTRIBUTE:
+      case sthDatabase.DATA_MODELS.COLLECTIONS_PER_ATTRIBUTE:
         theEvent = {
           recvTime: recvTime,
           attrType: sthTestConfig.ATTRIBUTE_TYPE,

--- a/test/node/sth_database_test.js
+++ b/test/node/sth_database_test.js
@@ -34,53 +34,8 @@
         });
     });
 
-    it('should generate the collection name for the event raw data', function () {
-      var collectionName;
-      switch(sthConfig.DATA_MODEL) {
-        case sthConfig.DATA_MODELS.COLLECTIONS_PER_SERVICE_PATH:
-          collectionName = sthConfig.COLLECTION_PREFIX + '_' + sthConfig.DEFAULT_SERVICE_PATH;
-          break;
-        case sthConfig.DATA_MODELS.COLLECTIONS_PER_ENTITY:
-          collectionName = sthConfig.COLLECTION_PREFIX + '_' + sthConfig.DEFAULT_SERVICE_PATH +
-            '_' + sthTestConfig.ENTITY_ID +
-            '_' + sthTestConfig.ENTITY_TYPE;
-          break;
-        case sthConfig.DATA_MODELS.COLLECTIONS_PER_ATTRIBUTE:
-          collectionName = sthConfig.COLLECTION_PREFIX + '_' + sthConfig.DEFAULT_SERVICE_PATH +
-            '_' + sthTestConfig.ENTITY_ID +
-            '_' + sthTestConfig.ENTITY_TYPE +
-            '_' + sthTestConfig.ATTRIBUTE_NAME +
-            '_' + sthTestConfig.ATTRIBUTE_TYPE;
-          break;
-      }
-      expect(collectionName4Events).to.equal(collectionName);
-    });
-
     it('should drop the event raw data collection if it exists',
       sthTestHelper.dropRawEventCollectionTest);
-
-    it('should generate the collection name for the aggregated data', function () {
-      var collectionName;
-      switch(sthConfig.DATA_MODEL) {
-        case sthConfig.DATA_MODELS.COLLECTIONS_PER_SERVICE_PATH:
-          collectionName = sthConfig.COLLECTION_PREFIX + '_' + sthConfig.DEFAULT_SERVICE_PATH;
-          break;
-        case sthConfig.DATA_MODELS.COLLECTIONS_PER_ENTITY:
-          collectionName = sthConfig.COLLECTION_PREFIX + '_' + sthConfig.DEFAULT_SERVICE_PATH +
-          '_' + sthTestConfig.ENTITY_ID +
-          '_' + sthTestConfig.ENTITY_TYPE;
-          break;
-        case sthConfig.DATA_MODELS.COLLECTIONS_PER_ATTRIBUTE:
-          collectionName = sthConfig.COLLECTION_PREFIX + '_' + sthConfig.DEFAULT_SERVICE_PATH +
-          '_' + sthTestConfig.ENTITY_ID +
-          '_' + sthTestConfig.ENTITY_TYPE +
-          '_' + sthTestConfig.ATTRIBUTE_NAME +
-          '_' + sthTestConfig.ATTRIBUTE_TYPE;
-          break;
-      }
-      collectionName += '.aggr';
-      expect(collectionName4Aggregated).to.equal(collectionName);
-    });
 
     it('should drop the aggregated data collection if it exists',
       sthTestHelper.dropAggregatedDataCollectionTest);


### PR DESCRIPTION
We decided to remove the option to select via a configuration parameter the data model to use when storing the raw event and aggregated data fixing it to collection per entity.

Anyhow, we decided to keep the code which deals with this option in case we decide to go back to any of the alternative supported data models.

- 100% tests passed.
- Assigned to @frbattid 