### PR TITLE
Using "-next" in version number for ongoing releases

### DIFF
--- a/CHANGES_NEXT_RELEASE
+++ b/CHANGES_NEXT_RELEASE
@@ -1,1 +1,1 @@
-* [BUG] Use dots (".") instead of minus ("-") in version codes for proper packaging (#108)
+- [BUG] Use "-next" in version number for ongoing releases (#113)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "fiware-comet",
   "description": "Node.js app exposing the Short Time Historic (STH) FIWARE component REST API for reading",
-  "version": "0.1.0.SNAPSHOT",
+  "version": "0.1.0-next",
   "repository": {
     "type": "git",
     "url": "https://github.com/telefonicaid/IoT-STH.git"


### PR DESCRIPTION
Just as it is done in https://github.com/telefonicaid/fiware-pep-steelskin and https://github.com/telefonicaid/perseo-fe

- 100% tests passed
- Fixes https://github.com/telefonicaid/IoT-STH/issues/113
- Assigned to @frbattid 