### PR TITLE
Convert to lowercase before generating the collection names or hashes

### DIFF
--- a/package/rpm/SPECS/sth.spec
+++ b/package/rpm/SPECS/sth.spec
@@ -157,3 +157,4 @@ rm -rf $RPM_BUILD_ROOT
 - [FEATURE] dateFrom and dateTo as optional parameters in queries (#53)
 - [FEATURE] Generate collection names using a hash function (#83)
 - [FEATURE] Set the SHOULD_HASH default option to false (#95)
+- [BUG] Entity id and entity type are converted to lowercase in Cygnus but not in STH (#119)

--- a/src/sth_database.js
+++ b/src/sth_database.js
@@ -327,7 +327,7 @@
     var connection = mongoose.connection.useDb(databaseName);
 
     // Get the connection and notify it via the callback.
-    sthLogger.debug('Getting access to the collection: ' + collectionName, {
+    sthLogger.debug('Getting access to the collection \'' + collectionName + '\' in database \'' + databaseName + '\'', {
       operationType: sthConfig.OPERATION_TYPE.DB_LOG
     });
     connection.db.collection(collectionName, {strict: true},

--- a/src/sth_database.js
+++ b/src/sth_database.js
@@ -208,6 +208,7 @@
           '_' + attrName;
         break;
     }
+    collectionName4Events = collectionName4Events.toLowerCase();
     if (sthConfig.SHOULD_HASH) {
       var limit = getHashSizeInBytes(databaseName);
       if (limit < MIN_HASH_SIZE_IN_BYTES) {
@@ -326,6 +327,9 @@
     var connection = mongoose.connection.useDb(databaseName);
 
     // Get the connection and notify it via the callback.
+    sthLogger.debug('Getting access to the collection: ' + collectionName, {
+      operationType: sthConfig.OPERATION_TYPE.DB_LOG
+    });
     connection.db.collection(collectionName, {strict: true},
       function (err, collection) {
         if (err &&


### PR DESCRIPTION
- 100% tests passed
- Fixes https://github.com/telefonicaid/IoT-STH/issues/119
- Assigned to @frbattid 

<b>THE `release/0.1.0-using-lowercase-for-collection-names-generation` BRANCH SHOULD NOT BE DELETED UNTIL IT LANDS INTO `master` (https://github.com/telefonicaid/IoT-STH/pull/120) AND `develop` (https://github.com/telefonicaid/IoT-STH/pull/123) TOO :)</b>