### PR TITLE
Correct date sorting for the hLimit + hOffset case

### DIFF
--- a/package/rpm/SPECS/sth.spec
+++ b/package/rpm/SPECS/sth.spec
@@ -158,3 +158,4 @@ rm -rf $RPM_BUILD_ROOT
 - [FEATURE] Generate collection names using a hash function (#83)
 - [FEATURE] Set the SHOULD_HASH default option to false (#95)
 - [BUG] Entity id and entity type are converted to lowercase in Cygnus but not in STH (#119)
+- [BUG] In raw request with hlimit and offset returns the last attributes firstly (#121)

--- a/src/sth_database.js
+++ b/src/sth_database.js
@@ -421,26 +421,33 @@
       findCondition.recvTime = recvTimeFilter;
     }
 
-    var cursor = collection.find(
-      findCondition,
-      {
-        _id: 0,
-        attrType: 1,
-        attrValue: 1,
-        recvTime: 1
-      }
-    ).sort({'recvTime': -1});
+    var cursor;
 
     if (lastN) {
-      cursor.limit(lastN).toArray(function(err, results) {
+      cursor = collection.find(
+        findCondition,
+        {
+          _id: 0,
+          attrType: 1,
+          attrValue: 1,
+          recvTime: 1
+        }
+      ).sort({'recvTime': -1}).limit(lastN).toArray(function(err, results) {
         if (!err) {
           results.reverse();
         }
         return process.nextTick(callback.bind(null, err, results));
       });
     } else {
-      cursor.skip(hOffset).limit(hLimit);
-      return cursor.toArray(callback);
+      cursor = collection.find(
+        findCondition,
+        {
+          _id: 0,
+          attrType: 1,
+          attrValue: 1,
+          recvTime: 1
+        }
+      ).sort({'recvTime': 1}).skip(hOffset).limit(hLimit).toArray(callback);
     }
   }
 


### PR DESCRIPTION
- 100% tests passed
- Fixes https://github.com/telefonicaid/IoT-STH/issues/121
- Assigned to @frbattid 

<b>THE `release/0.1.0-bug/correct-raw-data-data-sorting` BRANCH SHOULD NOT BE DELETED UNTIL IT LANDS INTO `master` (https://github.com/telefonicaid/IoT-STH/pull/125) AND `develop` (https://github.com/telefonicaid/IoT-STH/pull/126) TOO :)</b>