### PR TITLE
Now config.js and sth_default.conf are aligned

### DIFF
--- a/package/rpm/SOURCES/usr/sth/conf/sth_default.conf
+++ b/package/rpm/SOURCES/usr/sth/conf/sth_default.conf
@@ -36,14 +36,17 @@ export LOG_DIR="/var/log/sth"
 # The name of the file where the logs will be stored. Default value: "sth_app.log".
 export LOG_FILE_NAME="sth_default.log"
 
-# The prefix to be added to the service for the creation of the databases. More information below. Default value: "sth".
-export DB_PREFIX="sth"
+# The time in seconds between proof of life logging messages informing that the server is up and running normally. Default value: "60".
+export PROOF_OF_LIFE_INTERVAL="60"
+
+# The prefix to be added to the service for the creation of the databases. More information below. Default value: "sth_".
+export DB_PREFIX="sth_"
 
 # The service to be used if not sent by the Orion Context Broker in the notifications. Default value: "orion".
 export DEFAULT_SERVICE="orion"
 
-# The prefix to be added to the collections in the databases. More information below. Default value: "sth".
-export COLLECTION_PREFIX="sth"
+# The prefix to be added to the collections in the databases. More information below. Default value: "sth_".
+export COLLECTION_PREFIX="sth_"
 
 # The service path to be used if not sent by the Orion Context Broker in the notifications. Default value: "/".
 export DEFAULT_SERVICE_PATH="/"


### PR DESCRIPTION
This PR fixes https://github.com/telefonicaid/IoT-STH/issues/130

The branch `bug/fix_sth_default.conf_misalignment` shouldn't be deleted because it should be merged into `develop`.