### PR TITLE
Poiting to the new Docker hub organization for FIWARE

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ The STH component server is ready to be started.
 
 ##<a id="section4"></a> Automatic deployment using Docker
 To ease the testing and deployment of the STH component we have prepared a Docker repository which can be found at
-[https://registry.hub.docker.com/u/gtorodelvalle/iot-sth/](https://registry.hub.docker.com/u/gtorodelvalle/iot-sth/),
+[https://registry.hub.docker.com/u/fiwareiotplatform/iot-sth/](https://registry.hub.docker.com/u/fiwareiotplatform/iot-sth/),
 including all the information needed to try and to deploy the STH component via the execution of a simple Docker command.
 
 [Top](#section0)


### PR DESCRIPTION
- PLEASE, **DO NOT DELETE** THE `release/0.1.0-pointing_to_the_new_Docker_hub_organization` UNTIL IT HAS SUCCESSFULLY LANDED IN THE `release/0.1.0` (https://github.com/telefonicaid/IoT-STH/pull/162) AND `master` (https://github.com/telefonicaid/IoT-STH/pull/163) branches.
- 100% tests passed
- Assigned to @frbattid 