### PR TITLE
Configurable resolutions

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ value), `min (minimum value), `sum` (sum of all the samples) and `sum2` (sum of 
 attribute values and `occur` for attributes values of type string. Combining
 the information provided by these aggregated methods with the number of samples, it is possible to calculate probabilistic
 values such as the average value, the variance as well as the standard deviation. It is a mandatory parameter.
-* <b>aggrPeriod</b>: Aggregation period or resolution. A fixed resolution determines the the origin time format and the
+* <b>aggrPeriod</b>: Aggregation period or resolution. A fixed resolution determines the origin time format and the
 possible offsets. It is a mandatory parameter.
 * <b>dateFrom</b>: The origin of time from which the aggregated time series information is desired. It is an optional parameter.
 * <b>dateTo</b>: The end of time until which the aggregated time series information is desired. It is an optional parameter.

--- a/README.md
+++ b/README.md
@@ -42,22 +42,20 @@ it is the responsibility of the people or software in charge of creating the nee
 time series database twice (i.e. to avoid enabling both mechanisms at the same time). This would happen if both mechanisms
 are enabled for the same attribute of the same entity.
 
-Regarding the aggregated time series information provided by the STH component, there are 4 main concepts which are
+Regarding the aggregated time series information provided by the STH component, there are 3 main concepts which are
 important to know about:
 
-* <b>Range</b>: The period of time about which the aggregated time series information is provided. Possible valid
-ranges values are: year, month, day, hour, minute.
 * <b>Resolution</b> or <b>aggregation period</b>: The time period by which the aggregated time series information is grouped.
-Possible valid resolution values are: month, day, hour, minute and second. For the time being, we only consider the
-following range-resolution pairs: year-month, month-day, day-hour, hour-minute and minute-second.
-* <b>Origin</b>: For certain range-resolution pair, it is the origin of time for which the aggregated time series
-information applies. For example, for a pair hour-minute, a valid origin value could be: ```2015-03-01T13:00:00.000Z```,
+Possible valid resolution values are: month, day, hour, minute and second.
+* <b>Origin</b>: For certain resolution, it is the origin of time for which the aggregated time series
+information applies. For example, for a resolution of minutes, a valid origin value could be: ```2015-03-01T13:00:00.000Z```,
 meaning the 13th hour of March, the 3rd, 2015. The origin is stored using UTC time to avoid locale issues.
-* <b>Offset</b>: For certain range-resolution pair, it is the offset from the origin for which the aggregated time series
-information applies. For example, for a pair hour-minute and an origin ```2015-03-01T13:00:00.000Z```, an offset of 10
+* <b>Offset</b>: For certain resolution, it is the offset from the origin for which the aggregated time series
+information applies. For example, for a resolution of minutes and an origin ```2015-03-01T13:00:00.000Z```, an offset of 10
 refers to the 10th minute of the concrete hour pointed by the origin. In this example, there would be a maximum of 60
 offsets from 0 to 59 corresponding to each one of the 60 minutes within the concrete hour.
-* <b>Samples</b>: For a quadruple range-resolution-origin-offset, it is the number of samples, values, events or notifications available.
+* <b>Samples</b>: For a triple resolution, origin and offset, it is the number of samples, values, events or notifications available
+for that concrete offset from the origin.
 
 ###<a id="section1.1"></a> Consuming raw data
 
@@ -138,8 +136,8 @@ value), `min (minimum value), `sum` (sum of all the samples) and `sum2` (sum of 
 attribute values and `occur` for attributes values of type string. Combining
 the information provided by these aggregated methods with the number of samples, it is possible to calculate probabilistic
 values such as the average value, the variance as well as the standard deviation. It is a mandatory parameter.
-* <b>aggrPeriod</b>: Aggregation period or resolution. For the time being, a fixed resolution determines the range as
-well as the origin time format and the possible offsets. It is a mandatory parameter.
+* <b>aggrPeriod</b>: Aggregation period or resolution. A fixed resolution determines the the origin time format and the
+possible offsets. It is a mandatory parameter.
 * <b>dateFrom</b>: The origin of time from which the aggregated time series information is desired. It is an optional parameter.
 * <b>dateTo</b>: The end of time until which the aggregated time series information is desired. It is an optional parameter.
 
@@ -157,7 +155,6 @@ An example response provided by the STH component to a request such as the previ
                             {
                                 "_id": {
                                     "origin": "2015-02-18T02:46:00.000Z",
-                                    "range": "minute",
                                     "resolution": "second"
                                 },
                                 "points": [
@@ -183,7 +180,7 @@ An example response provided by the STH component to a request such as the previ
 }
 </pre>
 
-In this example response, aggregated time series information for a range of minutes and a resolution of seconds is returned.
+In this example response, aggregated time series information for a resolution of seconds is returned.
 This information has as its origin the 46nd minute, of the 2nd hour of February, the 18th, 2015. And includes data for the
 13th second, for which there is a sample and the sum (and value of that sample) is 34.59.
 
@@ -206,7 +203,6 @@ may end up receiving the following payload as a possible response:
                             {
                                 "_id": {
                                     "origin": "2015-02-18T02:46:00.000Z",
-                                    "range": "minute",
                                     "resolution": "second"
                                 },
                                 "points": [
@@ -352,11 +348,18 @@ The STH component provides the user with 2 mechanisms to configure the component
 
 * Environment variables, which can be set assigning values to them or using the `sth_default.conf` file if a packaged
 version of the STH component is used.
-* The [`config.js`](https://github.com/telefonicaid/IoT-STH/blob/develop/config.js) located at the root of the STH component code, a JSON formatted file including the configuration properties.
+* The [`config.js`](https://github.com/telefonicaid/IoT-STH/blob/develop/config.js) file located at the root of the STH component code, a JSON formatted file including the configuration properties.
 
-It is important to note that environment variables, if set, take precedence over the properties defined in the `config.js` file.
+It is important to note that environment variables, if set, take precedence over the properties defined in the
+[`config.js`](https://github.com/telefonicaid/IoT-STH/blob/develop/config.js) file.
 
-The script accepts the following parameters as environment variables:
+On the other hand, it is also important to note that the aggregation resolutions can only be configured using the
+[`config.js`](https://github.com/telefonicaid/IoT-STH/blob/develop/config.js) file and
+consequently this is the preferred way to configure the STH component behavior. The mentioned resolutions can be configured using
+the `config.server.aggregation` property in the [`config.js`](https://github.com/telefonicaid/IoT-STH/blob/develop/config.js) file
+including the desired resolution to be used when aggregating data. Accepted resolution values include: `month`, `day`, `hour`, `minute` and `second`.
+
+In case of preferring using environment variables, the script accepts the following parameters as environment variables:
 
 - STH_HOST: The host where the STH server will be started. Optional. Default value: "localhost".
 - STH_PORT: The port where the STH server will be listening. Optional. Default value: "8666".

--- a/config.js
+++ b/config.js
@@ -11,7 +11,10 @@ config.server = {
   port: '8666',
   // A flag indicating if the empty results should be removed from the response.
   //  Default value: "true".
-  filterOutEmpty: 'true'
+  filterOutEmpty: 'true',
+  // Array of resolutions the STH component should aggregate values for.
+  // Valid resolution values are: 'month', 'day', 'hour', 'minute' and 'second'
+  aggregation: ['day', 'hour', 'minute']
 };
 
 // Database configuration

--- a/src/sth_configuration.js
+++ b/src/sth_configuration.js
@@ -12,17 +12,8 @@
   var dbPassword = ENV.DB_PASSWORD || config.database.password || '';
 
   module.exports = {
-    RANGE: {
-      YEAR: 'year',
-      MONTH: 'month',
-      WEEK: 'week',
-      DAY: 'day',
-      HOUR: 'hour',
-      MINUTE: 'minute'
-    },
     RESOLUTION: {
       MONTH: 'month',
-      WEEK: 'week',
       DAY: 'day',
       HOUR: 'hour',
       MINUTE: 'minute',
@@ -63,6 +54,7 @@
   } else {
     module.exports.LOG_TO_CONSOLE = true;
   }
+
   if (ENV.LOG_TO_FILE) {
     module.exports.LOG_TO_FILE = ENV.LOG_TO_FILE !== 'false';
   } else if (config.logging.toFile) {
@@ -70,6 +62,7 @@
   } else {
     module.exports.LOG_TO_FILE = true;
   }
+
   if (!isNaN(ENV.LOG_FILE_MAX_SIZE_IN_BYTES)) {
     module.exports.LOG_FILE_MAX_SIZE_IN_BYTES = parseInt(ENV.LOG_FILE_MAX_SIZE_IN_BYTES);
   } else if (!isNaN(config.logging.maxFileSize)) {
@@ -77,8 +70,13 @@
   } else {
     module.exports.LOG_FILE_MAX_SIZE_IN_BYTES = 0;
   }
+
   module.exports.LOG_DIR = ENV.LOG_DIR || config.logging.directoryPath || ('.' + path.sep + 'log');
+
   module.exports.LOG_FILE_NAME = ENV.LOG_FILE_NAME || config.logging.fileName || 'sth_app.log';
+
+  var sthLogger = require('./sth_logger')(module.exports);
+
   if (!isNaN(ENV.PROOF_OF_LIFE_INTERVAL)) {
     module.exports.PROOF_OF_LIFE_INTERVAL = ENV.PROOF_OF_LIFE_INTERVAL;
   } else if (!isNaN(config.logging.proofOfLifeInterval)) {
@@ -86,8 +84,11 @@
   } else {
     module.exports.PROOF_OF_LIFE_INTERVAL = '60';
   }
+
   module.exports.DEFAULT_SERVICE = ENV.DEFAULT_SERVICE || config.database.defaultService || 'orion';
+
   module.exports.DEFAULT_SERVICE_PATH = ENV.DEFAULT_SERVICE_PATH || config.database.defaultServicePath || '/';
+
   if (ENV.POOL_SIZE && !isNaN(ENV.POOL_SIZE) && parseInt(ENV.POOL_SIZE) > 0) {
     module.exports.POOL_SIZE = parseInt(ENV.POOL_SIZE);
   } else if (config.database.poolSize && !isNaN(config.database.poolSize) && parseInt(config.database.poolSize) > 0) {
@@ -95,6 +96,7 @@
   } else {
     module.exports.POOL_SIZE = 5;
   }
+
   try {
     if (ENV.WRITE_CONCERN && (!isNaN(ENV.WRITE_CONCERN) || ENV.WRITE_CONCERN === 'majority' || JSON.parse(ENV.WRITE_CONCERN))) {
       module.exports.WRITE_CONCERN = ENV.WRITE_CONCERN;
@@ -106,6 +108,7 @@
   } catch (exception) {
     module.exports.WRITE_CONCERN = config.database.writeConcern || 1;
   }
+
   if ([
       module.exports.DATA_TO_STORE.ONLY_RAW,
       module.exports.DATA_TO_STORE.ONLY_AGGREGATED,
@@ -121,6 +124,7 @@
   } else {
     module.exports.SHOULD_STORE = 'both';
   }
+
   if (ENV.SHOULD_HASH) {
     module.exports.SHOULD_HASH = ENV.SHOULD_HASH !== 'false';
   } else if (config.database.shouldHash) {
@@ -128,6 +132,7 @@
   } else {
     module.exports.SHOULD_HASH = false;
   }
+
   if (ENV.TRUNCATION_EXPIREAFTERSECONDS) {
     module.exports.TRUNCATION_EXPIREAFTERSECONDS = ENV.TRUNCATION_EXPIREAFTERSECONDS;
   } else if (config.database.truncation.expireAfterSeconds) {
@@ -135,6 +140,7 @@
   } else {
     module.exports.TRUNCATION_EXPIREAFTERSECONDS = '0';
   }
+
   if (ENV.TRUNCATION_SIZE) {
     module.exports.TRUNCATION_SIZE = ENV.TRUNCATION_SIZE;
   } else if (config.database.truncation.size) {
@@ -142,6 +148,7 @@
   } else {
     module.exports.TRUNCATION_SIZE = '0'
   }
+
   if (ENV.TRUNCATION_MAX) {
     module.exports.TRUNCATION_MAX = ENV.TRUNCATION_MAX;
   } else if (config.database.truncation.max) {
@@ -149,13 +156,20 @@
   } else {
     module.exports.TRUNCATION_MAX = '0'
   }
+
   module.exports.DB_USERNAME = dbUsername;
+
   module.exports.DB_PASSWORD = dbPassword;
+
   module.exports.DB_AUTHENTICATION = (dbUsername && dbPassword) ?
       (dbUsername + ':' + dbPassword) : '';
+
   module.exports.DB_URI = ENV.DB_URI || config.database.URI || 'localhost:27017';
+
   module.exports.REPLICA_SET = ENV.REPLICA_SET || config.database.replicaSet || '';
+
   module.exports.STH_HOST = ENV.STH_HOST || config.server.host || 'localhost';
+
   if (!isNaN(ENV.STH_PORT)) {
     module.exports.STH_PORT = parseInt(ENV.STH_PORT);
   } else if (!isNaN(config.server.port)) {
@@ -163,6 +177,27 @@
   } else {
     module.exports.STH_PORT = 8666;
   }
+
+  module.exports.AGGREGATION = [];
+  if (config.server.aggregation && config.server.aggregation.length) {
+    config.server.aggregation.forEach(function(entry) {
+      if (module.exports.RESOLUTION[entry.toUpperCase()]) {
+        module.exports.AGGREGATION.push(entry);
+      } else {
+        sthLogger.warn('The following aggregation configuration is not valid: ' + JSON.stringify(entry) +
+          '. It will be ignored. Please, see the component documentation in Github to fix it.', {
+          operationType: module.exports.OPERATION_TYPE.SERVER_START
+        });
+      }
+    });
+  }
+  if (module.exports.AGGREGATION.length === 0) {
+    sthLogger.warn('No valid aggregation configuration has been set. Nothing will be aggregated. Please, configure it in the ' +
+      'config.js file according to the component documentation in Github.', {
+      operationType: module.exports.OPERATION_TYPE.SERVER_START
+    });
+  }
+
   if (ENV.FILTER_OUT_EMPTY) {
     module.exports.FILTER_OUT_EMPTY = ENV.FILTER_OUT_EMPTY !== 'false';
   } else if (config.server.filterOutEmpty) {

--- a/src/sth_database.js
+++ b/src/sth_database.js
@@ -476,21 +476,18 @@
             '_id.entityId': entityId,
             '_id.entityType': entityType,
             '_id.attrName': attrName,
-            '_id.resolution': resolution,
-            '_id.range': sthHelper.getRange(resolution)
+            '_id.resolution': resolution
           };
           break;
         case DATA_MODELS.COLLECTIONS_PER_ENTITY:
           matchCondition = {
             '_id.attrName': attrName,
-            '_id.resolution': resolution,
-            '_id.range': sthHelper.getRange(resolution)
+            '_id.resolution': resolution
           };
           break;
         case DATA_MODELS.COLLECTIONS_PER_ATTRIBUTE:
           matchCondition = {
-            '_id.resolution': resolution,
-            '_id.range': sthHelper.getRange(resolution)
+            '_id.resolution': resolution
           };
           break;
       }
@@ -506,7 +503,6 @@
             entityType: '$_id.entityType',
             attrName: '$_id.attrName',
             origin: '$_id.origin',
-            range: '$_id.range',
             resolution: '$_id.resolution'
           };
           break;
@@ -514,14 +510,12 @@
           groupId = {
             attrName: '$_id.attrName',
             origin: '$_id.origin',
-            range: '$_id.range',
             resolution: '$_id.resolution'
           };
           break;
         case DATA_MODELS.COLLECTIONS_PER_ATTRIBUTE:
           groupId = {
             origin: '$_id.origin',
-            range: '$_id.range',
             resolution: '$_id.resolution'
           };
           break;
@@ -563,21 +557,18 @@
             '_id.entityId': entityId,
             '_id.entityType': entityType,
             '_id.attrName': attrName,
-            '_id.resolution': resolution,
-            '_id.range': sthHelper.getRange(resolution)
+            '_id.resolution': resolution
           };
           break;
         case DATA_MODELS.COLLECTIONS_PER_ENTITY:
           findCondition = {
             '_id.attrName': attrName,
-            '_id.resolution': resolution,
-            '_id.range': sthHelper.getRange(resolution)
+            '_id.resolution': resolution
           };
           break;
         case DATA_MODELS.COLLECTIONS_PER_ATTRIBUTE:
           findCondition = {
-            '_id.resolution': resolution,
-            '_id.range': sthHelper.getRange(resolution)
+            '_id.resolution': resolution
           };
           break;
       }
@@ -614,7 +605,6 @@
           '_id.attrName': attrName,
           '_id.origin': sthHelper.getOrigin(recvTime, resolution),
           '_id.resolution': resolution,
-          '_id.range': sthHelper.getRange(resolution),
           'points.offset': offset
         };
         break;
@@ -623,7 +613,6 @@
           '_id.attrName': attrName,
           '_id.origin': sthHelper.getOrigin(recvTime, resolution),
           '_id.resolution': resolution,
-          '_id.range': sthHelper.getRange(resolution),
           'points.offset': offset
         };
         break;
@@ -631,7 +620,6 @@
         aggregateUpdateCondition = {
           '_id.origin': sthHelper.getOrigin(recvTime, resolution),
           '_id.resolution': resolution,
-          '_id.range': sthHelper.getRange(resolution),
           'points.offset': offset
         };
         break;
@@ -795,7 +783,7 @@
       );
      */
     // Prepopulate the aggregated data collection if there is no entry for the concrete
-    //  origin, resolution and range.
+    //  origin and resolution.
     collection.update(
       getAggregateUpdateCondition(
         entityId, entityType, attrName, resolution, recvTime),
@@ -848,30 +836,16 @@
         error;
     function onCompletion(err) {
       error = err;
-      if (++counter === 5) {
+      if (++counter === sthConfig.AGGREGATION.length) {
         callback(err);
       }
     }
 
-    storeAggregatedData4Resolution(
-      collection, entityId, entityType, attrName, attrType, attrValue,
-      sthConfig.RESOLUTION.SECOND, recvTime, onCompletion);
-
-    storeAggregatedData4Resolution(
-      collection, entityId, entityType, attrName, attrType, attrValue,
-      sthConfig.RESOLUTION.MINUTE, recvTime, onCompletion);
-
-    storeAggregatedData4Resolution(
-      collection, entityId, entityType, attrName, attrType, attrValue,
-      sthConfig.RESOLUTION.HOUR, recvTime, onCompletion);
-
-    storeAggregatedData4Resolution(
-      collection, entityId, entityType, attrName, attrType, attrValue,
-      sthConfig.RESOLUTION.DAY, recvTime, onCompletion);
-
-    storeAggregatedData4Resolution(
-      collection, entityId, entityType, attrName, attrType, attrValue,
-      sthConfig.RESOLUTION.MONTH, recvTime, onCompletion);
+    sthConfig.AGGREGATION.forEach(function(entry) {
+      storeAggregatedData4Resolution(
+        collection, entityId, entityType, attrName, attrType, attrValue,
+        entry, recvTime, onCompletion);
+    });
   }
 
   /**

--- a/src/sth_helper.js
+++ b/src/sth_helper.js
@@ -47,32 +47,6 @@
   }
 
   /**
-   * Returns the range associated to certain resolution
-   * @param {string} resolution The resolution (typically, second, minute,
-   *  hour, day or month)
-   * @returns {string} The range associated to the passed resolution
-   */
-  function getRange(resolution) {
-    var RESOLUTION = sthConfig.RESOLUTION,
-      RANGE = sthConfig.RANGE;
-    if (resolution === RESOLUTION.MONTH) {
-      return RANGE.YEAR;
-    } else if (resolution === RESOLUTION.WEEK) {
-      return RANGE.YEAR;
-    } else if (resolution === RESOLUTION.DAY) {
-      return RANGE.MONTH;
-    } else if (resolution === RESOLUTION.HOUR) {
-      return RANGE.DAY;
-    } else if (resolution === RESOLUTION.MINUTE) {
-      return RANGE.HOUR;
-    } else if (resolution === RESOLUTION.SECOND) {
-      return RANGE.MINUTE;
-    } else {
-      return null;
-    }
-  }
-
-  /**
    * Returns the offset of a date for certain resolution
    * @param resolution The resolution
    * @param date The date
@@ -242,7 +216,6 @@
     sthLogger = aSthLogger;
     return {
       getOrigin: getOrigin,
-      getRange: getRange,
       getOffset: getOffset,
       getEmptyResponse: getEmptyResponse,
       getUnicaCorrelator: getUnicaCorrelator,

--- a/src/sth_server.js
+++ b/src/sth_server.js
@@ -443,7 +443,10 @@
               }
             );
             var error = boom.badRequest(message);
-            error.output.payload.validation = {source: 'query', keys: ['lastN', 'hLimit', 'hOffset', 'aggrMethod', 'aggrPeriod']};
+            error.output.payload.validation = {
+              source: 'query',
+              keys: ['lastN', 'hLimit', 'hOffset', 'aggrMethod', 'aggrPeriod']
+            };
             return reply(error);
           }
         },

--- a/test/node/sth_app_test_helper.js
+++ b/test/node/sth_app_test_helper.js
@@ -195,7 +195,7 @@
       addEventTest(anEvent, done);
     });
 
-    it('should store aggregated data for each pair resolution - range',
+    it('should store aggregated data for each resolution',
       function(done) {
         addAggregatedDataTest(anEvent, done);
       }
@@ -516,8 +516,6 @@
         to.equal(attrName || sthTestConfig.ATTRIBUTE_NAME);
       expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values[0]._id.resolution).
         to.equal(resolution);
-      expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values[0]._id.range).
-        to.equal(sthHelper.getRange(resolution));
       expect(bodyJSON.contextResponses[0].contextElement.attributes[0].values[0]._id.origin).
         to.be(sthHelper.getISODateString(
           sthHelper.getOrigin(
@@ -626,65 +624,19 @@
    */
   function aggregatedDataRetrievalSuite(attrName, attrType, aggrMethod) {
     describe('with aggrMethod as ' + aggrMethod, function() {
-      describe('and aggrPeriod as ' + sthConfig.RESOLUTION.SECOND, function() {
-        it('should respond with empty aggregated data if no data since dateFrom',
-          noAggregatedDataSinceDateTest.bind(
-            null, sthConfig.DEFAULT_SERVICE, sthConfig.DEFAULT_SERVICE_PATH, attrName, attrType, aggrMethod,
-            sthConfig.RESOLUTION.SECOND));
+      for (var i = 0; i < sthConfig.AGGREGATION.length; i++) {
+        describe('and aggrPeriod as ' + sthConfig.AGGREGATION[i], function() {
+          it('should respond with empty aggregated data if no data since dateFrom',
+            noAggregatedDataSinceDateTest.bind(
+              null, sthConfig.DEFAULT_SERVICE, sthConfig.DEFAULT_SERVICE_PATH, attrName, attrType, aggrMethod,
+              sthConfig.AGGREGATION[i]));
 
-        it('should respond with aggregated data if data since dateFrom',
-          aggregatedDataAvailableSinceDateTest.bind(
-            null, sthConfig.DEFAULT_SERVICE, sthConfig.DEFAULT_SERVICE_PATH, attrName, attrType, aggrMethod,
-            sthConfig.RESOLUTION.SECOND));
-      });
-
-      describe('and aggrPeriod as minute', function() {
-        it('should respond with empty aggregated data if no data since dateFrom',
-          noAggregatedDataSinceDateTest.bind(
-            null, sthConfig.DEFAULT_SERVICE, sthConfig.DEFAULT_SERVICE_PATH, attrName, attrType, aggrMethod,
-            sthConfig.RESOLUTION.MINUTE));
-
-        it('should respond with aggregated data if data since dateFrom',
-          aggregatedDataAvailableSinceDateTest.bind(
-            null, sthConfig.DEFAULT_SERVICE, sthConfig.DEFAULT_SERVICE_PATH, attrName, attrType, aggrMethod,
-            sthConfig.RESOLUTION.MINUTE));
-      });
-
-      describe('and aggrPeriod as hour', function() {
-        it('should respond with empty aggregated data if no data since dateFrom',
-          noAggregatedDataSinceDateTest.bind(
-            null, sthConfig.DEFAULT_SERVICE, sthConfig.DEFAULT_SERVICE_PATH, attrName, attrType, aggrMethod,
-            sthConfig.RESOLUTION.HOUR));
-
-        it('should respond with aggregated data if data since dateFrom',
-          aggregatedDataAvailableSinceDateTest.bind(
-            null, sthConfig.DEFAULT_SERVICE, sthConfig.DEFAULT_SERVICE_PATH, attrName, attrType, aggrMethod,
-            sthConfig.RESOLUTION.HOUR));
-      });
-
-      describe('and aggrPeriod as day', function() {
-        it('should respond with empty aggregated data if no data since dateFrom',
-          noAggregatedDataSinceDateTest.bind(
-            null, sthConfig.DEFAULT_SERVICE, sthConfig.DEFAULT_SERVICE_PATH, attrName, attrType, aggrMethod,
-            sthConfig.RESOLUTION.DAY));
-
-        it('should respond with aggregated data if data since dateFrom',
-          aggregatedDataAvailableSinceDateTest.bind(
-            null, sthConfig.DEFAULT_SERVICE, sthConfig.DEFAULT_SERVICE_PATH, attrName, attrType, aggrMethod,
-            sthConfig.RESOLUTION.DAY));
-      });
-
-      describe('and aggrPeriod as month', function() {
-        it('should respond with empty aggregated data if no data since dateFrom',
-          noAggregatedDataSinceDateTest.bind(
-            null, sthConfig.DEFAULT_SERVICE, sthConfig.DEFAULT_SERVICE_PATH, attrName, attrType, aggrMethod,
-            sthConfig.RESOLUTION.MONTH));
-
-        it('should respond with aggregated data if data since dateFrom',
-          aggregatedDataAvailableSinceDateTest.bind(
-            null, sthConfig.DEFAULT_SERVICE, sthConfig.DEFAULT_SERVICE_PATH, attrName, attrType, aggrMethod,
-            sthConfig.RESOLUTION.MONTH));
-      });
+          it('should respond with aggregated data if data since dateFrom',
+            aggregatedDataAvailableSinceDateTest.bind(
+              null, sthConfig.DEFAULT_SERVICE, sthConfig.DEFAULT_SERVICE_PATH, attrName, attrType, aggrMethod,
+              sthConfig.AGGREGATION[i]));
+        });
+      }
     });
   }
 


### PR DESCRIPTION
The concept of range has been deleted from the STH component since it really does not apply. In fact, the STH is able to generate aggregate values for distinct resolutions (currently months, days, hours, minutes and seconds) and provides support to get that aggregated information for certain range of dates (using the `dateFrom` and `dateTo` URL parameters). Those parameters are more than enough to get the aggregated information between certain dates aggregated using the desired resolution.

Fixes https://github.com/telefonicaid/IoT-STH/issues/173
Fixes https://github.com/telefonicaid/IoT-STH/issues/172
Fixes https://github.com/telefonicaid/IoT-STH/issues/171

- 100% tests passed
- Assigned to @frbattid 